### PR TITLE
Add optional support for credentials in environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Browser load testing the IDP using k6s
 1. `brew install k6`
 2. Fill Microsoft credentials to `credentials.js` for example script (`login.js`), either by
     1. Writing credentials directly to file
-    2. Using [Bitwarden CLI](https://bitwarden.com/help/cli) to set env variables in Bash, eg
+    2. Setting env variables, eg
        ```bash
-        export EMAIL=$(bw get username Microsoft)
-        export PASSWORD=$(bw get password Microsoft)
+        export EMAIL="user@example.com"
+        export PASSWORD="example-password"
        ```
 
 Docs for [installing k6](https://grafana.com/docs/k6/latest/set-up/install-k6/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@ Browser load testing the IDP using k6s
 
 ## Setup
 1. `brew install k6`
-2. Fill Microsoft credentials to `credentials.js` for example script (`login.js`)
+2. Fill Microsoft credentials to `credentials.js` for example script (`login.js`), either by
+    1. Writing credentials directly to file
+    2. Using [Bitwarden CLI](https://bitwarden.com/help/cli) to set env variables in Bash, eg
+       ```bash
+        export EMAIL=$(bw get username Microsoft)
+        export PASSWORD=$(bw get password Microsoft)
+       ```
 
 Docs for [installing k6](https://grafana.com/docs/k6/latest/set-up/install-k6/)
 

--- a/credentials.js
+++ b/credentials.js
@@ -2,3 +2,10 @@ module.exports = {
     EMAIL: '',
     PASSWORD: ''
 }
+
+if (`${__ENV.EMAIL}`) {
+    module.exports.EMAIL = `${__ENV.EMAIL}`;
+}
+if (`${__ENV.PASSWORD}`) {
+    module.exports.PASSWORD = `${__ENV.PASSWORD}`;
+}


### PR DESCRIPTION
# Overview

Allows for passwords to be stored in either `credentials.json` or retrieved from an external password manager (e.g. with the [Bitwarden CLI](https://bitwarden.com/help/cli))

# Example usage

```sh
# Use the `bw` password manager command to retrieve credentials
➜ export EMAIL=$(bw get username Microsoft)
➜ export PASSWORD=$(bw get password Microsoft)
➜ k6 run login.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: login.js
        output: -

...

running (24.3s), 0/1 VUs, 3 complete and 0 interrupted iterations
ui   ✓ [======================================] 1 VUs  20s
```